### PR TITLE
Skip static validation

### DIFF
--- a/lib/graphql/query.rb
+++ b/lib/graphql/query.rb
@@ -405,7 +405,6 @@ module GraphQL
 
       @validation_pipeline = GraphQL::Query::ValidationPipeline.new(
         query: self,
-        validate: @validate,
         parse_error: parse_error,
         operation_name_error: operation_name_error,
         max_depth: @max_depth,

--- a/lib/graphql/query/validation_pipeline.rb
+++ b/lib/graphql/query/validation_pipeline.rb
@@ -16,9 +16,8 @@ module GraphQL
     class ValidationPipeline
       attr_reader :max_depth, :max_complexity
 
-      def initialize(query:, validate:, parse_error:, operation_name_error:, max_depth:, max_complexity:)
+      def initialize(query:, parse_error:, operation_name_error:, max_depth:, max_complexity:)
         @validation_errors = []
-        @validate = validate
         @parse_error = parse_error
         @operation_name_error = operation_name_error
         @query = query
@@ -65,7 +64,7 @@ module GraphQL
         elsif @operation_name_error
           @validation_errors << @operation_name_error
         else
-          validation_result = @schema.static_validator.validate(@query, validate: @validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
+          validation_result = @schema.static_validator.validate(@query, validate: @query.validate, timeout: @schema.validate_timeout, max_errors: @schema.validate_max_errors)
           @validation_errors.concat(validation_result[:errors])
 
           if @validation_errors.empty?

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -699,6 +699,13 @@ describe GraphQL::Query do
       query = GraphQL::Query.new(schema, invalid_query_string, validate: true)
       assert_equal false, query.valid?
       assert_equal 1, query.static_errors.length
+
+      # Can assign attribute after calling methods that use the AST
+      query = GraphQL::Query.new(schema, invalid_query_string)
+      assert query.fingerprint
+      query.validate = false
+      assert_equal true, query.valid?
+      assert_equal 0, query.static_errors.length
     end
   end
 


### PR DESCRIPTION
This PR skips static validation for a graphql operation by setting `query.skip_static_validation = true`. This allows us to skip static validation for repeated operations for which this result can be cached.

Variable validation runs irrespective whether or not static validation is skipped.