### PR TITLE
Add outline of idea

### DIFF
--- a/lib/graphql/tracing/opentelementry_tracing.rb
+++ b/lib/graphql/tracing/opentelementry_tracing.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Instrumentation
+    module GraphQL
+      module Tracers
+        # GraphQLTracer contains the OpenTelemetry tracer implementation compatible with
+        # the GraphQL tracer API
+        class GraphQLTracer < ::GraphQL::Tracing::PlatformTracing
+          self.platform_keys = {
+            'lex' => 'graphql.lex',
+            'parse' => 'graphql.parse',
+            'validate' => 'graphql.validate',
+            'analyze_query' => 'graphql.analyze_query',
+            'analyze_multiplex' => 'graphql.analyze_multiplex',
+            'execute_query' => 'graphql.execute_query',
+            'execute_query_lazy' => 'graphql.execute_query_lazy',
+            'execute_multiplex' => 'graphql.execute_multiplex'
+          }
+
+          def platform_trace(platform_key, key, data)
+            return yield if platform_key.nil?
+
+            tracer.in_span(platform_key, attributes: attributes_for(key, data)) do |span|
+              yield.tap do |response|
+                errors = response[:errors]&.compact&.map { |e| e.to_h }&.to_json if key == 'validate'
+                unless errors.nil?
+                  span.add_event(
+                    'graphql.validation.error',
+                    attributes: {
+                      'message' => errors
+                    }
+                  )
+                end
+              end
+            end
+          end
+
+          def platform_field_key(type, field, context) # TODO: pass in context
+            # If global setting is not enabled, return nil such that nothing is traced
+            return unless config[:enable_platform_field]
+
+            # If context setting is not set or enabled, return nil such that nothing is traced
+            ns = context.namespace(:opentelemetry)
+            return unless ns.key?(:enable_platform_field) && ns[:enable_platform_field]
+
+            # Otherwise this is the key
+            "#{type.graphql_name}.#{field.graphql_name}"
+          end
+
+          def platform_authorized_key(type, context) # TODO: pass in context
+            return unless config[:enable_platform_authorized]
+
+            # If context setting is not set or enabled, return nil such that nothing is traced
+            ns = context.namespace(:opentelemetry)
+            return unless ns.key?(:enable_platform_field) && ns[:enable_platform_authorized]
+
+            "#{type.graphql_name}.authorized"
+          end
+
+          def platform_resolve_type_key(type, context) # TODO: pass in context
+            return unless config[:enable_platform_resolve_type]
+
+            # If context setting is not set or enabled, return nil such that nothing is traced
+            ns = context.namespace(:opentelemetry)
+            return unless ns.key?(:enable_platform_field) && ns[:enable_platform_resolve_type]
+
+            "#{type.graphql_name}.resolve_type"
+          end
+
+          private
+
+          def tracer
+            GraphQL::Instrumentation.instance.tracer
+          end
+
+          def config
+            GraphQL::Instrumentation.instance.config
+          end
+
+          def attributes_for(key, data)
+            attributes = {}
+            case key
+            when 'execute_query'
+              attributes['selected_operation_name'] = data[:query].selected_operation_name if data[:query].selected_operation_name
+              attributes['selected_operation_type'] = data[:query].selected_operation.operation_type
+              attributes['query_string'] = data[:query].query_string
+            end
+            attributes
+          end
+
+          def cached_platform_key(ctx, key, key_type) # key_type is one of :field, :authorized, :resolve_type
+            cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
+            # cache.fetch(key) { cache[key] = yield }
+            cache.fetch(key) begin
+              cache[key] = if key_type == :field
+                platform_field_key(data[:owner], field, ctx)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/tracing/platform_tracing.rb
+++ b/lib/graphql/tracing/platform_tracing.rb
@@ -41,7 +41,7 @@ module GraphQL
 
             platform_key = if trace_field
               context = data.fetch(:query).context
-              cached_platform_key(context, field) { platform_field_key(data[:owner], field) }
+              cached_platform_key(context, field, :field) { platform_field_key(data[:owner], field) }
             else
               nil
             end
@@ -57,14 +57,14 @@ module GraphQL
         when "authorized", "authorized_lazy"
           type = data.fetch(:type)
           context = data.fetch(:context)
-          platform_key = cached_platform_key(context, type) { platform_authorized_key(type) }
+          platform_key = cached_platform_key(context, type, :authorized) { platform_authorized_key(type) }
           platform_trace(platform_key, key, data) do
             yield
           end
         when "resolve_type", "resolve_type_lazy"
           type = data.fetch(:type)
           context = data.fetch(:context)
-          platform_key = cached_platform_key(context, type) { platform_resolve_type_key(type) }
+          platform_key = cached_platform_key(context, type, :resolve_type) { platform_resolve_type_key(type) }
           platform_trace(platform_key, key, data) do
             yield
           end
@@ -112,8 +112,10 @@ module GraphQL
       # If the key isn't present, the given block is called and the result is cached for `key`.
       #
       # @return [String]
-      def cached_platform_key(ctx, key)
+      def cached_platform_key(ctx, key, trace_phase)
         cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
+        # trace_phase is one of :field, :authorized, :resolve_type
+        # Instead of the yield, we could call custom functions, but data[:owner] is no longer available to us
         cache.fetch(key) { cache[key] = yield }
       end
     end


### PR DESCRIPTION
Accept a third parameter, `trace_phase` for `cached_platform_key` to know which function is being traced.

`cached_platform_key` has `context`, so we can look into it to make informed decisions about the platform key that should be built.

However, with `platform_field_key`, we pass in the GraphQL type and field being traced. The GraphQL type is determined by `data[:owner]`, but this information is not passed into `cached_platform_key` (value is in scope only to code block passed in), meaning we cannot have a fully custom solution to building a platform key.

This includes a modified copy of the [OpenTelemetry implementation](https://github.com/open-telemetry/opentelemetry-ruby/blob/99bfe640cef822adb5f173937b7a98c7d5c48758/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb) to demonstrate how they would work together.